### PR TITLE
Fixes #8 - adding a dynamic metric

### DIFF
--- a/examples/collector/rand.py
+++ b/examples/collector/rand.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 import logging
+import os
 import random
 import time
 
@@ -42,9 +43,12 @@ class Rand(snap.Collector):
                 "int64": random.randint(
                     metric.config["int_min"],
                     metric.config["int_max"]
-                    )
+                    ),
+                "*": os.getuid()
             }
-            typ = metric.namespace[len(metric.namespace)-1].Value
+            typ = metric.namespace[1].value
+            if typ == "*":
+                metric.namespace[1].value = str(os.getpid())
             metric.data = switch[typ]
             metric.timestamp = time.time()
         return metrics
@@ -63,6 +67,14 @@ class Rand(snap.Collector):
                 Description="Random {}".format(key),
             )
             metrics.append(metric)
+
+        # add a dynamic metric
+        metric = snap.Metric(version=1, Description="dynamic element example")
+        metric.namespace.add_static_element("random")
+        metric.namespace.add_dynamic_element("pid", "current pid")
+        metric.namespace.add_static_element("uid")
+        metrics.append(metric)
+
         return metrics
 
     def get_config_policy(self):

--- a/examples/tasks/rand-py-task.yml
+++ b/examples/tasks/rand-py-task.yml
@@ -9,6 +9,7 @@
                 /random/float64: {}
                 /random/int64: {}
                 /random/string: {}
+                /random/*/uid: {}
             process:
                 - plugin_name: "tag-py"
                   publish:

--- a/examples/tasks/rand-py-task.yml
+++ b/examples/tasks/rand-py-task.yml
@@ -10,6 +10,7 @@
                 /random/int64: {}
                 /random/string: {}
                 /random/*/uid: {}
+                /random/*/gid: {}
             process:
                 - plugin_name: "tag-py"
                   publish:

--- a/snap_plugin/v1/namespace.py
+++ b/snap_plugin/v1/namespace.py
@@ -68,7 +68,7 @@ class Namespace(object):
         Returns:
             :py:class:`snap_plugin.v1.namespace.Namespace`
         """
-        self._pb.add(Name=name, Description=description)
+        self._pb.add(Name=name, Description=description, Value="*")
         return self
 
     def add_static_element(self, value):

--- a/snap_plugin/v1/namespace_element.py
+++ b/snap_plugin/v1/namespace_element.py
@@ -22,17 +22,18 @@ from .plugin_pb2 import NamespaceElement as PbNamespaceElement
 class NamespaceElement(object):
     """Namespace element of a metric.
 
-    A static namespace element is defined by the `value` attribute being set
-    and where the `name` attribute is not used (set to None).  This is the case
-    when the namespace does not change based on what is being collected.
+    A namespace element is static when the `value` attribute is set
+    and where the `name` attribute is not set.  This is the case when the 
+    namespace does not change based on what is being collected.
 
-    A dynamic namespace element is defined by an element that contains a
+    A dynamic namespace element is defined by an element that contains
     non-static data relative to the metric being collected.  For instance, when
     collecting metrics for a given virtual machine the namespace element that
     contains the virtual-machine-id would be dynamic.  This is modeled by
-    the a NamespaceElement when its `name` attribute contains the value
+    the NamespaceElement when its `name` attribute contains the value
     'virtual-machine-id'.  In this example the `value` attribute would be set
-    to the ID of the virtual machine when the metric is collected.
+    to the ID of the virtual machine when the metric is collected and '*' when
+    the metric catalog is updated.
 
     Args:
         value (:obj:`str`): The value of an element.
@@ -49,6 +50,11 @@ class NamespaceElement(object):
             self._pb.Value = value
             self._pb.Description = description
             self._pb.Name = name
+            if name != "" and value == "":
+                # If the name is provided it's a dynamic metric.
+                # If the value field is not also set it needs to be set to the
+                # default '*'.
+                self._pb.Value = "*"
 
     def __getattr__(self, attr):
         if attr in self.__dict__:

--- a/snap_plugin/v1/tests/test_metric.py
+++ b/snap_plugin/v1/tests/test_metric.py
@@ -121,7 +121,7 @@ class TestMetric(object):
         # add a dynamic namespace element
         m.namespace.add_dynamic_element("el3", "i'm dynamic!")
         assert len(m.namespace) == 4
-        assert (m.namespace[3].value == "" and
+        assert (m.namespace[3].value == "*" and
                 m.namespace[3].name == "el3" and
                 m.namespace[3].description == "i'm dynamic!")
         # pop/remove the last element of the namespace


### PR DESCRIPTION
Fixes #8 

Summary of changes:
- Adds a "*" to the value field of the namespace element when adding a dynamic element

Testing done:
- unit
- manual

![img](https://www.dropbox.com/s/zs93rlhm2xo80xm/issue8.gif?raw=1)

@intelsdi-x/snap-maintainers
