### PR TITLE
Fixes #12 - printing metric.config fails

### DIFF
--- a/snap_plugin/v1/config_map.py
+++ b/snap_plugin/v1/config_map.py
@@ -81,8 +81,10 @@ class ConfigMap(MutableMapping):
         raise KeyError(key)
 
     def __repr__(self):
-        return repr(self._pb.StringMap.items() + self._pb.IntMap.items() +
-                    self._pb.FloatMap.items() + self._pb.BoolMap.items())
+        return repr(dict(chain(self._pb.StringMap.items(),
+                               self._pb.IntMap.items(),
+                               self._pb.FloatMap.items(),
+                               self._pb.BoolMap.items())))
 
     def __len__(self):
         return (len(self._pb.IntMap) + len(self._pb.StringMap) +

--- a/snap_plugin/v1/tests/test_metric.py
+++ b/snap_plugin/v1/tests/test_metric.py
@@ -150,6 +150,10 @@ class TestMetric(object):
                 m.config["int"] == 1 and
                 m.config["bool"] is True)
 
+        # verify an error is not raised
+        # https://github.com/intelsdi-x/snap-plugin-lib-py/issues/12
+        repr(m.config)
+
         with pytest.raises(AttributeError) as excinfo:
                 m.config = ConfigMap()
         assert "can't set attribute" in str(excinfo.value)


### PR DESCRIPTION
This issue is related to compatability between Python2 and Python3.  The object representation of snap.v1.ConfigMap has been updated to return a dict that is the union of the  maps.