### PR TITLE
Added support for plugin diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # <img src="http://snap-telemetry.io/assets/img/snap_url.png" align="middle" height="75">Snap Plugin Library for Python
 
 This is a library for writing plugins in Python for the
-[Snap telemetry framework](https://github.com/intelsdi-x/snap) to get started
-authoring a plugin checkout:
-# [https://intelsdi-x.github.io/snap-plugin-lib-py/](https://intelsdi-x.github.io/snap-plugin-lib-py/)
+[Snap telemetry framework](https://github.com/intelsdi-x/snap).
 
+----
 
-## Brief Overview of Snap Architecture
+1. [Brief overview of Snap architecture](#brief-overview-of-snap-architecture)
+2. [Writing a plugin](#writing-a-plugin)
+    * [Before writing a Snap plugin](#before-writing-a-snap-plugin)
+3. [Example plugins](#example-plugins)
+4. [Plugin diagnostics](#plugin-diagnostics)
+    * [Custom config](#custom-config)
+    * [Custom flags](#custom-flags)
 
-For an overiew of Snap checkout: [http://snap-telemetry.io/](http://snap-telemetry.io/)
+## Brief overview of Snap architecture
+
+For an overview of Snap checkout: [http://snap-telemetry.io/](http://snap-telemetry.io/)
 
 Snap is an open and modular telemetry framework designed to simplify the
 collection, processing and publishing of data through a single HTTP based API.
@@ -22,7 +29,11 @@ as protocol buffer messages (see
 [plugin.proto](https://github.com/intelsdi-x/snap/blob/master/control/plugin/rpc/plugin.proto)).
 The Snap daemon handshakes with the plugin over stdout and then communicates over gRPC.
 
-### Before writing a Snap plugin:
+## Writing a plugin
+
+For reference on authoring plugins see [library's documentation](https://intelsdi-x.github.io/snap-plugin-lib-py/).
+
+### Before writing a Snap plugin
 
 * See if one already exists in the
 [Plugin Catalog](https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_CATALOG.md)
@@ -32,3 +43,79 @@ The Snap daemon handshakes with the plugin over stdout and then communicates ove
 If you do decide to write a plugin, open a new issue following the plugin
 [wishlist guidelines](https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_CATALOG.md#wish-list)
  and let us know you are working on one!
+
+## Example plugins
+
+You will find example plugins that cover the basics for writing collector, processor, and publisher plugins in the [examples folder](https://github.com/intelsdi-x/snap-plugin-lib-py/tree/master/examples).
+
+## Plugin diagnostics
+
+Snap collector plugins using lib-py can be run independent of Snap to show their current running diagnostics.
+
+To run diagnostic simply execute your plugin (just make sure all dependencies are met in your environment).
+
+Diagnostic information includes:
+
+* Runtime details
+    * Plugin name and version
+    * RPC type and version
+    * OS, architecture
+    * Python version
+* Config policy
+    * Warning if config items required and not provided
+* Collectible metrics and their current values
+* How long it took to run each of these diagnostics
+
+### Custom config
+
+While running diagnostic you might (or must, if plugin requires it) specify additional config for plugin.
+
+To do so you can run your plugin with `--config` flag and provide valid JSON argument. For example:
+```sh
+./myplugin.py --config '{"key": "value", "answer": "42"}'
+```
+
+### Custom flags
+
+You can also specify your own CLI flags to change behaviour of your plugin while running diagnostics.
+
+#### Flag format
+
+Flag uses following format: `(name, type, description, (optional) default value)`:
+
+`name`: name of your flag under which it will be accessible to use
+
+**Note**: To access values of flags with names containing hyphens `-` you need to replace them with underscore `_`.
+
+`type`: value of enum `snap_plugin.v1.plugin.FlagType` which indicate if your flag should act as a bool toggle, or store value
+
+`description`: description for your flag visible while using `--help` option
+
+`default value`: default value for your flag, which will be available if user doesn't specify any value
+
+#### Adding flags
+
+Flags must be added in your plugin's constructor, **after** calling superclass constructor.
+
+To add your flag you can use methods `add` and `add_multiple` of object `self._flags`:
+```python
+import snap_plugin.v1 as snap
+
+class MyPlugin(snap.Collector):
+    def __init__(self, *args, **kwargs):
+        super(MyPlugin, self).__init__(*args, **kwargs)
+        self._flags.add('require-config', snap.plugin.FlagType.toggle, 'require additional config')
+        self._flags.add_multiple([('stand-alone', snap.plugin.FlagType.toggle, 'enable stand alone mode'), ('port', FlagType.value, 'port to run on', 8080)])
+```
+
+#### Accessing flag values
+
+Flag values can be accessed at `self._args` object:
+```python
+
+if self._args.require_config:
+    # note changing hyphen to underscore in flag name when accessing it
+    pass
+```
+
+As always, if you have any questions, please reach out to the Snap team via [Slack](https://intelsdi-x.herokuapp.com/) or by opening an issue in Github.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ grpcio>=1.1.3,<2
 protobuf>=3.2.0,<4
 futures>=3.0.5 ; python_version < '3'
 future>=0.16.0
+tabulate>=0.7.7
 versioneer>=0.18

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=['grpcio>=1.1.3,<2', 'protobuf>=3.2.0,<4',
-                      'futures>=3.0.5', 'future>=0.16.0'],
+                      'futures>=3.0.5', 'future>=0.16.0', 'tabulate>=0.7.7'],
     author="Joel Cooklin",
     author_email="joel.cooklin@gmail.com",
     description="This is a lib for creating plugins for the Snap telementry "

--- a/snap_plugin/v1/__init__.py
+++ b/snap_plugin/v1/__init__.py
@@ -27,7 +27,7 @@ https://intelsdi-x.github.io/snap-plugin-lib-py/.
 
 __all__ = ['Collector', 'Processor', 'Publisher', 'Metric', 'Namespace',
            'NamespaceElement', 'ConfigMap', 'StringRule', 'IntegerRule',
-           'BoolRule', 'FloatRule', 'ConfigPolicy']
+           'BoolRule', 'FloatRule', 'ConfigPolicy', 'FlagType']
 
 import logging
 import sys
@@ -44,6 +44,7 @@ from .string_policy import StringRule
 from .integer_policy import IntegerRule
 from .bool_policy import BoolRule
 from .float_policy import FloatRule
+from .plugin import FlagType
 from ._version import get_versions
 
 LOG = logging.getLogger()

--- a/snap_plugin/v1/config_map.py
+++ b/snap_plugin/v1/config_map.py
@@ -19,6 +19,7 @@
 from builtins import int
 from collections import MutableMapping
 from itertools import chain
+from past.builtins import basestring
 
 from .plugin_pb2 import ConfigMap as PbConfigMap
 
@@ -67,7 +68,7 @@ class ConfigMap(MutableMapping):
             self._pb.BoolMap[key] = item
         elif isinstance(item, int):
             self._pb.IntMap[key] = item
-        elif isinstance(item, str):
+        elif isinstance(item, basestring):
             self._pb.StringMap[key] = item
         else:
             raise TypeError("The type is '{}' and should be string, int, long, float "

--- a/snap_plugin/v1/config_policy.py
+++ b/snap_plugin/v1/config_policy.py
@@ -136,6 +136,14 @@ class ConfigPolicy(object):
                             self._pb.float_policy[key].rules.items()))
         return type('Rules', (object,), {"rules": rules})
 
+    @property
+    def policies(self):
+        """Return list of policies zipped with their respective data type"""
+        policies = [self._pb.integer_policy, self._pb.float_policy,
+                    self._pb.string_policy, self._pb.bool_policy]
+        key_types = ["integer", "float", "string", "bool"]
+        return zip(key_types, policies)
+
 
 def _check_key(key):
     errors = []

--- a/snap_plugin/v1/namespace.py
+++ b/snap_plugin/v1/namespace.py
@@ -50,6 +50,24 @@ class Namespace(object):
     def __len__(self):
         return len(self._pb)
 
+    def __repr__(self):
+        separators = ["/", "|", "%", ":", "-", ";", "_", "^", ">", "<", "+", "=", "&", "㊽", "Ä", "大", "小", "ᵹ", "☍", "ヒ"]
+        separator = "\U0001f422"
+        for sep in separators:
+            found = False
+            for n in self:
+                if sep in n.value:
+                    found = True
+                    break
+            if not found:
+                separator = sep
+                break
+
+        result = separator
+        for n in self:
+            result += n.value + separator
+        return result[:-1]
+
     def add_dynamic_element(self, name, description):
         """Adds a dynamic namespace element to the end of the Namespace.
 

--- a/snap_plugin/v1/tests/test_metric.py
+++ b/snap_plugin/v1/tests/test_metric.py
@@ -152,7 +152,3 @@ class TestMetric(object):
         # verify an error is not raised
         # https://github.com/intelsdi-x/snap-plugin-lib-py/issues/12
         repr(m.config)
-
-        with pytest.raises(AttributeError) as excinfo:
-                m.config = ConfigMap()
-        assert "can't set attribute" in str(excinfo.value)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,6 +13,7 @@ testrepository>=0.0.18 # Apache-2.0/BSD
 testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=1.4.0 # MIT
 pytest>=3.0.3
+pytest-catchlog>=1.2.2
 pytest-cov>=2.4.0
 recommonmark==0.4.0
 sphinx-rtd-theme==0.1.9


### PR DESCRIPTION
Added diagnostic mode to lib.
If plugin is run without config from framework present, it will start in diagnostic mode.
Plugin authors also have an option to add flags, so they can change behaviour of the plugin based on presence/value of CLI args.

TODO:

- [x] Add documentation to README
- [x] Add tests
