### PR TITLE
Add standalone

### DIFF
--- a/snap_plugin/v1/plugin.py
+++ b/snap_plugin/v1/plugin.py
@@ -270,6 +270,7 @@ class Plugin(object):
         self._mode = PluginMode.normal
         self._config = {}
         self._flags = _Flags()
+        self.standalone_server = None
 
         # init argparse module and add arguments
         self._parser = argparse.ArgumentParser(description="%(prog)s - a Snap framework plugin.",
@@ -335,7 +336,7 @@ class Plugin(object):
             preamble = self._generate_preamble_and_serve()
             try:
                 handler = _make_standalone_handler(preamble)
-                server = HTTPServer(('', int(self._args.stand_alone_port)), handler)
+                self.standalone_server = HTTPServer(('', int(self._args.stand_alone_port)), handler)
             except (OSError, socket_error) as err:
                 if err.errno == 98:
                     LOG.error("Port {} already in use.".format(self._args.stand_alone_port))
@@ -346,11 +347,11 @@ class Plugin(object):
                     raise
             else:
                 try:
-                    sys.stdout.write("Plugin loaded at {}:{}\n".format(*server.server_address))
+                    sys.stdout.write("Plugin loaded at {}:{}\n".format(*self.standalone_server.server_address))
                     sys.stdout.flush()
-                    server.serve_forever()
+                    self.standalone_server.serve_forever()
                 except KeyboardInterrupt:
-                    server.socket.close()
+                    self.standalone_server.socket.close()
 
         elif self._mode == PluginMode.diagnostics and self.meta.type == PluginType.collector:
             self._print_diagnostic()

--- a/snap_plugin/v1/tests/mock_plugins.py
+++ b/snap_plugin/v1/tests/mock_plugins.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+# http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import time
+from builtins import int as bigint
+
+import snap_plugin.v1 as snap
+
+
+class MockCollector(snap.Collector, threading.Thread):
+    """Mock collector plugin """
+
+    def __init__(self, name, ver):
+        super(MockCollector, self).__init__(name, ver)
+        self._flags.add('require-config', snap.plugin.FlagType.toggle, '')
+        threading.Thread.__init__(self, group=None, target=None, name=None)
+        self._stopper = threading.Event()
+
+    def collect(self, metrics):
+        for metric in metrics:
+            metric.timestamp = time.time()
+            metric.version = 2
+            if "bytes" in metric.config and metric.config["bytes"] is True:
+                metric.data = b'qwerty'
+            elif "string" in metric.config and metric.config["string"] is True:
+                metric.data = "qwerty"
+            elif "int32" in metric.config and metric.config["int32"] is True:
+                metric.data = 99
+            elif "int64" in metric.config and metric.config["int64"] is True:
+                metric.data = bigint(99)
+            elif "bool" in metric.config and metric.config["bool"] is True:
+                metric.data = True
+            else:
+                metric.data = 99.9
+        return metrics
+
+    def update_catalog(self, config):
+        now = time.time()
+        metrics = [
+            snap.Metric(
+                namespace=[
+                    snap.NamespaceElement(value="acme"),
+                    snap.NamespaceElement(value="sk8"),
+                    snap.NamespaceElement(value="matix")
+                ],
+                unit="some unit",
+                description="some description",
+                timestamp=now,
+            )
+        ]
+        return metrics
+
+    def get_config_policy(self):
+        policy = [
+            ("acme", "sk8", "matix"),
+            [
+                (
+                    "password",
+                    snap.StringRule(default="grace", required=True),
+                ),
+                (
+                    "user",
+                    snap.StringRule(default="kristy", required=True),
+                ),
+            ]
+        ]
+
+        if self._args.require_config:
+            policy[1].append(("database", snap.StringRule(required=True)))
+
+        return snap.ConfigPolicy(policy)
+
+    def run(self):
+        self.start_plugin()
+
+    def stop(self):
+        self._stopper.set()
+        self.stop_plugin()
+
+
+class MockProcessor(snap.Processor, threading.Thread):
+    """Mock processor plugin """
+    def __init__(self, name, ver):
+        super(MockProcessor, self).__init__(name, ver)
+        threading.Thread.__init__(self, group=None, target=None, name=None)
+        self._stopper = threading.Event()
+
+    def process(self, metrics, config):
+        for metric in metrics:
+            for (k, v) in config.items():
+                metric.tags[k] = v
+            metric.tags["processed"] = "true"
+        return metrics
+
+    def get_config_policy(self):
+        return snap.ConfigPolicy(
+            [
+                None,
+                [
+                    (
+                        "some-config",
+                        snap.StringRule(default="some-value")
+                    )
+                ]
+            ],
+        )
+
+    def run(self):
+        self.start_plugin()
+
+    def stop(self):
+        self._stopper.set()
+        self.stopped = True
+        self.stop_plugin()
+
+
+class MockPublisher(snap.Publisher, threading.Thread):
+    """Mock publisher plugin """
+
+    def __init__(self, name, ver):
+        super(MockPublisher, self).__init__(name, ver)
+        threading.Thread.__init__(self, group=None, target=None, name=None)
+        self._stopper = threading.Event()
+
+    def publish(self, metrics, config):
+        assert len(config) == 4
+        assert config["foo"] == "bar"
+        assert config["port"] == 911
+        assert config["debug"] is True
+        assert config["availability"] == 99.9
+        assert len(metrics) > 0
+        return metrics
+
+    def get_config_policy(self):
+        raise NotImplementedError
+
+    def run(self):
+        self.start_plugin()
+
+    def stop(self):
+        self._stopper.set()
+        self.stopped = True
+        self.stop_plugin()

--- a/snap_plugin/v1/tests/test_plugin.py
+++ b/snap_plugin/v1/tests/test_plugin.py
@@ -15,6 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import sys
+import time
+from http.client import HTTPConnection
+from threading import Thread
 
 import pytest
 
@@ -22,20 +27,57 @@ from snap_plugin.v1.collector import Collector
 from snap_plugin.v1.processor import Processor
 from snap_plugin.v1.publisher import Publisher
 
+from .mock_plugins import MockCollector
 
-class TestPlugin(object):
 
-    def test_collector(self):
-        with pytest.raises(TypeError) as excinfo:
-            Collector("name", 1)
-        assert "Can't instantiate abstract class Collector" in str(excinfo.value)
+def test_collector():
+    with pytest.raises(TypeError) as excinfo:
+        Collector("name", 1)
+    assert "Can't instantiate abstract class Collector" in str(excinfo.value)
 
-    def test_processor(self):
-        with pytest.raises(TypeError) as excinfo:
-            Processor("name", 1)
-        assert "Can't instantiate abstract class Processor" in str(excinfo.value)
 
-    def test_publisher(self):
-        with pytest.raises(TypeError) as excinfo:
-            Publisher("name", 1)
-        assert "Can't instantiate abstract class Publisher" in str(excinfo.value)
+def test_processor():
+    with pytest.raises(TypeError) as excinfo:
+        Processor("name", 1)
+    assert "Can't instantiate abstract class Processor" in str(excinfo.value)
+
+
+def test_publisher():
+    with pytest.raises(TypeError) as excinfo:
+        Publisher("name", 1)
+    assert "Can't instantiate abstract class Publisher" in str(excinfo.value)
+
+
+def test_standalone(capsys, caplog):
+    sys.argv = ["", "--stand-alone", "--stand-alone-port", "0"]
+    col = MockCollector("MyCollector", 1)
+    thread = Thread(target=col.start)
+    thread.start()
+
+    # wait for stand alone server to start
+    time.sleep(.2)
+    out, _ = capsys.readouterr()
+    out = out.split()
+    address, port = out[-1].split(':')
+
+    connection = HTTPConnection(address, int(port), timeout=5)
+    connection.request("GET", "/")
+    response = connection.getresponse()
+    assert response.status == 200
+    data = response.read()
+    connection.close()
+
+    # response should be valid json
+    preamble = json.loads(data.decode('utf-8'))
+    # response should be valid preamble
+    assert "Meta" and "ListenAddress" in preamble
+
+    # try to start a standalone plugin on port already in use
+    sys.argv = ["", "--stand-alone", "--stand-alone-port", port]
+    col2 = MockCollector("MyCollector", 1)
+    col2.start()
+    time.sleep(.2)
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == 40
+
+    col.standalone_server.shutdown()

--- a/snap_plugin/v1/tests/test_publisher.py
+++ b/snap_plugin/v1/tests/test_publisher.py
@@ -17,7 +17,6 @@
 
 import json
 import sys
-import threading
 import time
 
 import grpc
@@ -28,35 +27,7 @@ from snap_plugin.v1.plugin_pb2 import PublisherStub
 from snap_plugin.v1.pub_proc_arg import _PublishArg
 
 from . import ThreadPrinter
-
-
-class MockPublisher(snap.Publisher, threading.Thread):
-    """Mock publisher plugin """
-
-    def __init__(self, name, ver):
-        super(MockPublisher, self).__init__(name, ver)
-        threading.Thread.__init__(self, group=None, target=None, name=None)
-        self._stopper = threading.Event()
-
-    def publish(self, metrics, config):
-        assert len(config) == 4
-        assert config["foo"] == "bar"
-        assert config["port"] == 911
-        assert config["debug"] is True
-        assert config["availability"] == 99.9
-        assert len(metrics) > 0
-        return metrics
-
-    def get_config_policy(self):
-        raise NotImplementedError
-
-    def run(self):
-        self.start_plugin()
-
-    def stop(self):
-        self._stopper.set()
-        self.stopped = True
-        self.stop_plugin()
+from .mock_plugins import MockPublisher
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Adds support for standalone mode.

Plugin started with --stand-alone flag will listen for HTTP requests on a port specified by --stand-alone-port flag (default 8181) and respond with plugin preamble.

TODO:

- [x] Add tests