### PR TITLE
Fix PyPI docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ python:
 install:
   - pip install -U pip wheel
   - pip install tox-travis
-  - pip install pypandoc
 script: tox
 deploy:
   provider: pypi

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,14 @@
+Snap Plugin Lib Py
+==================
+
+This is a library for writing plugins in Python for the Snap telemetry framework.
+
+Brief overview of Snap architecture
+-----------------------------------
+For an overview of Snap checkout: `http://snap-telemetry.io/ <http://snap-telemetry.io/>`_.
+
+Snap is an open and modular telemetry framework designed to simplify the collection, processing and publishing of data through a single HTTP based API. Plugins provide the functionality of collection, processing and publishing and can be loaded/unloaded, upgraded and swapped without requiring a restart of the Snap daemon.
+
+Writing a plugin
+----------------
+For reference on authoring plugins see `library's documentation <https://intelsdi-x.github.io/snap-plugin-lib-py/>`_ and `library's Github repo <https://github.com/intelsdi-x/snap-plugin-lib-py>`_.

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,10 @@
 from setuptools import setup, find_packages
 import versioneer
 
-try:
-    import pypandoc
-    long_description = pypandoc.convert('README.md', 'rst')
-except (IOError, ImportError):
-    long_description = open('README.md').read()
+
+def readme():
+    with open('README.rst') as f:
+        return f.read()
 
 setup(
     name="snap-plugin-lib-py",
@@ -33,7 +32,7 @@ setup(
     author="Joel Cooklin",
     author_email="joel.cooklin@gmail.com",
     description="This is a lib for creating plugins for the Snap telemetry framework.",
-    long_description=long_description,
+    long_description=readme(),
     license="Apache 2.0",
     keywords="snap telemetry plugin plugins metrics",
     url="http://github.com/intelsdi-x/snap-plugin-lib-py"


### PR DESCRIPTION
Added `README.rst` for PyPI description, as whole `README.md` isn't required there and conversion to reST was being problematic.